### PR TITLE
Do not check r1 return value for _GetNativeSystemInfo

### DIFF
--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -50,14 +50,12 @@ var (
 )
 
 func _GetNativeSystemInfo(systemInfo *SystemInfo) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetNativeSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(systemInfo)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+	_, _, e1 := syscall.Syscall(procGetNativeSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(systemInfo)), 0, 0)
+
+	if e1 != 0 {
+		err = errnoErr(e1)
 	}
+
 	return
 }
 


### PR DESCRIPTION
Do not check r1 return value for _GetNativeSystemInfo. Fixes issue with this syscall on 64-bit Windows