### PR TITLE
Do not expect return values from _GetNativeSystemInfo

### DIFF
--- a/kernel32.go
+++ b/kernel32.go
@@ -133,9 +133,7 @@ type MemoryStatusEx struct {
 // https://msdn.microsoft.com/en-us/library/ms724340%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
 func GetNativeSystemInfo() (SystemInfo, error) {
 	var systemInfo SystemInfo
-
 	_GetNativeSystemInfo(&systemInfo)
-
 	return systemInfo, nil
 }
 

--- a/kernel32.go
+++ b/kernel32.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Syscalls
-//sys   _GetNativeSystemInfo(systemInfo *SystemInfo) (err error) = kernel32.GetNativeSystemInfo
+//sys   _GetNativeSystemInfo(systemInfo *SystemInfo) = kernel32.GetNativeSystemInfo
 //sys   _GetTickCount64() (millis uint64, err error) = kernel32.GetTickCount64
 //sys   _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) = kernel32.GetSystemTimes
 //sys   _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) = kernel32.GlobalMemoryStatusEx
@@ -133,9 +133,9 @@ type MemoryStatusEx struct {
 // https://msdn.microsoft.com/en-us/library/ms724340%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
 func GetNativeSystemInfo() (SystemInfo, error) {
 	var systemInfo SystemInfo
-	if err := _GetNativeSystemInfo(&systemInfo); err != nil {
-		return SystemInfo{}, errors.Wrap(err, "GetNativeSystemInfo failed")
-	}
+
+	_GetNativeSystemInfo(&systemInfo)
+
 	return systemInfo, nil
 }
 

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -49,15 +49,8 @@ var (
 	procGetProcessMemoryInfo    = modpsapi.NewProc("GetProcessMemoryInfo")
 )
 
-func _GetNativeSystemInfo(systemInfo *SystemInfo) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetNativeSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(systemInfo)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
+func _GetNativeSystemInfo(systemInfo *SystemInfo) {
+	syscall.Syscall(procGetNativeSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(systemInfo)), 0, 0)
 	return
 }
 


### PR DESCRIPTION
Two changes:

Do not use return value or error from _GetNativeSystemInfo
Do not generate code which has return value or error

Fixes https://github.com/elastic/go-windows/issues/3