### PR TITLE
Add GetProcessHandleCount to kernel32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
   - GetProcessImageFileName
   - EnumProcesses
   [#6](https://github.com/elastic/go-windows/pull/6)
+* Add GetProcessHandleCount to kernel32: [#7](https://github.com/elastic/go-windows/pull/7)

--- a/kernel32.go
+++ b/kernel32.go
@@ -34,6 +34,7 @@ import (
 //sys   _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) = kernel32.GetSystemTimes
 //sys   _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) = kernel32.GlobalMemoryStatusEx
 //sys   _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (err error) = kernel32.ReadProcessMemory
+//sys   _GetProcessHandleCount(handle syscall.Handle, pdwHandleCount *uint32) (err error) = kernel32.GetProcessHandleCount
 
 var (
 	sizeofMemoryStatusEx = uint32(unsafe.Sizeof(MemoryStatusEx{}))
@@ -235,4 +236,14 @@ func ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, dest []byte) 
 		return 0, err
 	}
 	return numRead, nil
+}
+
+// GetProcessHandleCount retrieves the number of open handles of a process.
+// https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getprocesshandlecount
+func GetProcessHandleCount(process syscall.Handle) (uint32, error) {
+	var count uint32
+	if err := _GetProcessHandleCount(process, &count); err != nil {
+		return 0, errors.Wrap(err, "GetProcessHandleCount failed")
+	}
+	return count, nil
 }

--- a/kernel32_test.go
+++ b/kernel32_test.go
@@ -20,6 +20,7 @@
 package windows
 
 import (
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,17 @@ func TestGetTickCount64(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.True(t, millis > 0, "millis (%d) must be greater than 0", millis)
+}
+
+func TestGetProcessHandleCount(t *testing.T) {
+	h, err := syscall.GetCurrentProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := GetProcessHandleCount(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, count > 0)
 }

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -45,6 +45,7 @@ var (
 	procGetSystemTimes            = modkernel32.NewProc("GetSystemTimes")
 	procGlobalMemoryStatusEx      = modkernel32.NewProc("GlobalMemoryStatusEx")
 	procReadProcessMemory         = modkernel32.NewProc("ReadProcessMemory")
+	procGetProcessHandleCount     = modkernel32.NewProc("GetProcessHandleCount")
 	procGetFileVersionInfoW       = modversion.NewProc("GetFileVersionInfoW")
 	procGetFileVersionInfoSizeW   = modversion.NewProc("GetFileVersionInfoSizeW")
 	procVerQueryValueW            = modversion.NewProc("VerQueryValueW")
@@ -98,6 +99,18 @@ func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
 
 func _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadProcessMemory.Addr(), 5, uintptr(handle), uintptr(baseAddress), uintptr(buffer), uintptr(size), uintptr(unsafe.Pointer(numRead)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _GetProcessHandleCount(handle syscall.Handle, pdwHandleCount *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetProcessHandleCount.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(pdwHandleCount)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)


### PR DESCRIPTION
`GetProcessHandleCount` retrieves the number of open handles belonging to a process.

https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getprocesshandlecount