### PR TITLE
Use NewLazySystemDLL instead of NewLazyDLL

### DIFF
--- a/.ci/scripts/fix_generated.go
+++ b/.ci/scripts/fix_generated.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"regexp"
+)
+
+func main() {
+	var filename string
+
+	log.SetFlags(0)
+	flag.StringVar(&filename, "input", "", "name of generated source file to fix")
+	flag.Parse()
+
+	if filename == "" {
+		log.Fatal("Name of generated file must be specified with -input flag")
+	}
+
+	if err := fixGeneratedCode(filename); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var lazySystemRegex = regexp.MustCompile(`(?m)\sNewLazySystemDLL`)
+var unsafeImportRegex = regexp.MustCompile(`(?m)"unsafe"`)
+
+// fixGeneratedCode adds "windows." to locations in the generated source code
+// that reference "NewLazySystemDLL" without the package name.
+func fixGeneratedCode(filename string) error {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	data = lazySystemRegex.ReplaceAll(data, []byte(" windows.NewLazySystemDLL"))
+	data = unsafeImportRegex.ReplaceAll(data, []byte(`"unsafe"`+"\n\n\t"+`"golang.org/x/sys/windows"`))
+
+	return ioutil.WriteFile(filename, data, 0644)
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Load DLLs only from Windows system directory.
+
 ### Deprecated
 
 ### Removed

--- a/doc.go
+++ b/doc.go
@@ -20,4 +20,6 @@ package windows
 
 // Use "GOOS=windows go generate -v -x" to generate the sources.
 // Add -trace to enable debug prints around syscalls.
-//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=false -output zsyscall_windows.go kernel32.go version.go psapi.go ntdll.go
+//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=true -output=zsyscall_windows.go kernel32.go version.go psapi.go ntdll.go
+//go:generate go run .ci/scripts/fix_generated.go -input zsyscall_windows.go
+//go:generate go-licenser

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,5 @@ module github.com/elastic/go-windows
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 )

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -22,6 +22,8 @@ package windows
 import (
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var _ unsafe.Pointer
@@ -52,10 +54,10 @@ func errnoErr(e syscall.Errno) error {
 }
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-	modversion  = syscall.NewLazyDLL("version.dll")
-	modpsapi    = syscall.NewLazyDLL("psapi.dll")
-	modntdll    = syscall.NewLazyDLL("ntdll.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	modversion  = windows.NewLazySystemDLL("version.dll")
+	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
+	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
 
 	procGetNativeSystemInfo       = modkernel32.NewProc("GetNativeSystemInfo")
 	procGetTickCount64            = modkernel32.NewProc("GetTickCount64")


### PR DESCRIPTION
The ensures that the code only search for DLLs in the Windows system directory.