### PR TITLE
Fix test-reporter trigger

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -4,7 +4,7 @@ name: test-reporter
 on:
   workflow_run:
     workflows:
-      - test
+      - ci
     types:
       - completed
 


### PR DESCRIPTION
The test-reporter is currently not triggered, because of a wrong workflow name.